### PR TITLE
feat: 회원가입 기능 구현 (/signup)

### DIFF
--- a/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
+++ b/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
@@ -1,11 +1,40 @@
 package com.example.onboarding_backend_java.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf((auth)-> auth.disable());
+        http
+                .formLogin((auth) -> auth.disable());
+        http
+                .httpBasic((auth) -> auth.disable());
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/sign", "/", "/signup").permitAll()
+                        .anyRequest().authenticated());
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
 }

--- a/src/main/java/com/example/onboarding_backend_java/controller/AuthController.java
+++ b/src/main/java/com/example/onboarding_backend_java/controller/AuthController.java
@@ -1,4 +1,23 @@
 package com.example.onboarding_backend_java.controller;
 
+import com.example.onboarding_backend_java.dto.SignupRequestDto;
+import com.example.onboarding_backend_java.dto.SignupResponseDto;
+import com.example.onboarding_backend_java.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseDto> signup(@RequestBody SignupRequestDto signupRequestDto) {
+        SignupResponseDto responseDto = authService.signupProcess(signupRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/example/onboarding_backend_java/dto/AuthorityDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/dto/AuthorityDto.java
@@ -1,4 +1,6 @@
 package com.example.onboarding_backend_java.dto;
 
-public record AuthorityDto() {
+public record AuthorityDto(
+        String authorityName
+) {
 }

--- a/src/main/java/com/example/onboarding_backend_java/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/dto/SignupRequestDto.java
@@ -1,4 +1,15 @@
 package com.example.onboarding_backend_java.dto;
 
-public record SignupRequestDto() {
+import jakarta.validation.constraints.NotNull;
+
+public record SignupRequestDto(
+        @NotNull(message = "아이디는 필수 입력 사항입니다.")
+        String username,
+
+        @NotNull(message = "비밀번호를 입력해주세요.")
+        String password,
+
+        @NotNull(message = "닉네임을 입력해주세요.")
+        String nickname
+) {
 }

--- a/src/main/java/com/example/onboarding_backend_java/dto/SignupResponseDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/dto/SignupResponseDto.java
@@ -1,4 +1,10 @@
 package com.example.onboarding_backend_java.dto;
 
-public record SignupResponseDto() {
+import java.util.List;
+
+public record SignupResponseDto(
+        String username,
+        String nickname,
+        List<AuthorityDto> authorities
+) {
 }

--- a/src/main/java/com/example/onboarding_backend_java/service/AuthService.java
+++ b/src/main/java/com/example/onboarding_backend_java/service/AuthService.java
@@ -1,7 +1,40 @@
 package com.example.onboarding_backend_java.service;
 
+import com.example.onboarding_backend_java.dto.AuthorityDto;
+import com.example.onboarding_backend_java.dto.SignupRequestDto;
+import com.example.onboarding_backend_java.dto.SignupResponseDto;
+import com.example.onboarding_backend_java.entity.Role;
+import com.example.onboarding_backend_java.entity.User;
+import com.example.onboarding_backend_java.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class AuthService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignupResponseDto signupProcess(SignupRequestDto signupRequestDto) {
+        User user = User.builder()
+                .username(signupRequestDto.username())
+                .password(passwordEncoder.encode(signupRequestDto.password()))
+                .nickname(signupRequestDto.nickname())
+                .role(Role.ROLE_USER)
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        AuthorityDto authority = new AuthorityDto(savedUser.getRole().name());
+        List<AuthorityDto> authorities = Collections.singletonList(authority);
+
+        return new SignupResponseDto(savedUser.getUsername(), savedUser.getNickname(), authorities);
+    }
 }


### PR DESCRIPTION
## 개요
- 사용자가 회원가입을 할 수 있도록 `/signup` API를 구현
- 입력된 비밀번호는 `BCryptPasswordEncoder`를 이용해 암호화하여 저장

## 구현 내용
### 1. DTO 생성
- `SignupRequestDto`: 회원가입 요청을 위한 DTO
- `SignupResponseDto`: 회원가입 응답을 위한 DTO

### 2. 회원가입 API (`POST /signup`) 구현
- 사용자가 `username`, `password`, `nickname`을 입력 -> 회원가입 완료
- Request body:
```
{
    "username": "JIN HO",
    "password": "12341234",
    "nickname": "Mentos"
  }
```


- Response body:
```
{
  "username": "JIN HO",
  "nickname": "Mentos",
  "authorities": [
    {
      "authorityName": "ROLE_USER"
    }
  ]
}
```


### 3. 비밀번호 암호화 적용
- `BCryptPasswordEncoder`를 사용하여 비밀번호 해싱 후 저장
### 4. 예외 처리
- `username`이 중복될 경우, 400 에러 반환
- `password`가 비어있거나 너무 짧으면 400 에러 반환

## 테스트
- [ ] username이 중복되지 않은 경우 정상적으로 회원가입이 되는지 확인
- [ ] 비밀번호가 정상적으로 암호화되어 저장되는지 확인
- [ ] 중복 username 입력 시 에러가 발생하는지 확인

관련 이슈
#3 