### PR TITLE
feat: JWT 로그인 구현

### DIFF
--- a/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
+++ b/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.onboarding_backend_java.config;
 
 import com.example.onboarding_backend_java.security.jwt.JWTAuthenticationFilter;
+import com.example.onboarding_backend_java.security.jwt.JWTAuthorizationFilter;
 import com.example.onboarding_backend_java.security.jwt.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +47,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/sign", "/", "/signup").permitAll()
                         .anyRequest().authenticated())
+                .addFilterBefore(new JWTAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
+++ b/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
@@ -1,18 +1,27 @@
 package com.example.onboarding_backend_java.config;
 
+import com.example.onboarding_backend_java.security.jwt.JWTAuthenticationFilter;
+import com.example.onboarding_backend_java.security.jwt.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JWTUtil jwtUtil;
+
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -20,21 +29,27 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        JWTAuthenticationFilter jwtFilter =
+                new JWTAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+        jwtFilter.setFilterProcessesUrl("/sign");
 
         http
-                .csrf((auth)-> auth.disable());
-        http
-                .formLogin((auth) -> auth.disable());
-        http
-                .httpBasic((auth) -> auth.disable());
-        http
+                .csrf((auth) -> auth.disable())
+                .formLogin((auth) -> auth.disable())
+                .httpBasic((auth) -> auth.disable())
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/sign", "/", "/signup").permitAll()
-                        .anyRequest().authenticated());
-        http
+                        .anyRequest().authenticated())
+                .addFilterAt(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
         return http.build();
     }
 }

--- a/src/main/java/com/example/onboarding_backend_java/dto/SignRequestDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/dto/SignRequestDto.java
@@ -1,4 +1,13 @@
 package com.example.onboarding_backend_java.dto;
 
-public record SignRequestDto() {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+public class SignRequestDto {
+    private String username;
+    private String password;
 }

--- a/src/main/java/com/example/onboarding_backend_java/dto/SignResponseDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/dto/SignResponseDto.java
@@ -1,4 +1,0 @@
-package com.example.onboarding_backend_java.dto;
-
-public record SignResponseDto() {
-}

--- a/src/main/java/com/example/onboarding_backend_java/entity/User.java
+++ b/src/main/java/com/example/onboarding_backend_java/entity/User.java
@@ -1,14 +1,12 @@
 package com.example.onboarding_backend_java.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Builder
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class User {

--- a/src/main/java/com/example/onboarding_backend_java/entity/User.java
+++ b/src/main/java/com/example/onboarding_backend_java/entity/User.java
@@ -1,7 +1,10 @@
 package com.example.onboarding_backend_java.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
@@ -25,4 +28,5 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
 }

--- a/src/main/java/com/example/onboarding_backend_java/repository/UserRepository.java
+++ b/src/main/java/com/example/onboarding_backend_java/repository/UserRepository.java
@@ -4,10 +4,12 @@ import com.example.onboarding_backend_java.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
 
-    User findByUsername(String username);
+    Optional<User> findByUsername(String username);
 
     Boolean existsByUsername(String username);
 }

--- a/src/main/java/com/example/onboarding_backend_java/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/CustomUserDetailsService.java
@@ -16,11 +16,8 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username);
-
-        if (user != null) {
-            return new CustomUserDetails(user);
-        }
-        return null;
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+        return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthFilter.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthFilter.java
@@ -1,4 +1,0 @@
-package com.example.onboarding_backend_java.security.jwt;
-
-public class JWTAuthFilter {
-}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthenticationFilter.java
@@ -1,0 +1,85 @@
+package com.example.onboarding_backend_java.security.jwt;
+
+import com.example.onboarding_backend_java.dto.SignRequestDto;
+import com.example.onboarding_backend_java.security.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response) throws AuthenticationException {
+        try {
+            SignRequestDto signRequestDto = objectMapper.readValue(request.getInputStream(), SignRequestDto.class);
+            String username = signRequestDto.getUsername();
+            String password = signRequestDto.getPassword();
+            log.info("attemptAuthentication: username={}, password={}", username, password);
+
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(username, password, null);
+
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            log.error("attemptAuthentication: {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain,
+            Authentication authentication) throws IOException {
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+        log.info("successfulAuthentication: username={}, role={}", username, role);
+
+        String token = jwtUtil.createToken(username, role, 60 * 60 * 10 * 1000L);
+        log.info("Generated token: {}", token);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"token\":\"" + token + "\"}");
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException failed) throws IOException {
+        log.error("unsuccessfulAuthentication: {}", failed.getMessage());
+
+        response.setStatus(401);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"error\": \"자격 증명에 실패하였습니다.\"}");
+    }
+
+}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthorizationFilter.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthorizationFilter.java
@@ -1,0 +1,72 @@
+package com.example.onboarding_backend_java.security.jwt;
+
+import com.example.onboarding_backend_java.entity.Role;
+import com.example.onboarding_backend_java.entity.User;
+import com.example.onboarding_backend_java.security.CustomUserDetails;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JWTAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+
+            String authorization = request.getHeader("Authorization");
+
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
+
+                log.info("token null");
+                filterChain.doFilter(request, response);
+                return;
+            }
+            log.info("authorization now");
+
+            String token = authorization.substring(7);
+
+            if (jwtUtil.isExpired(token)) {
+                log.info("token expired");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            String username = jwtUtil.getUsername(token);
+            String role = jwtUtil.getRole(token);
+
+            User user = new User();
+            user.setUsername(username);
+            user.setPassword("temppassword");
+            user.setRole(Role.valueOf(role));
+
+            CustomUserDetails customUserDetails = new CustomUserDetails(user);
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    customUserDetails,
+                    null,
+                    customUserDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
+            filterChain.doFilter(request, response);
+        } catch(JwtException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("인가 중 서버 및 내부 오류 발생: ", e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTUtil.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTUtil.java
@@ -1,4 +1,70 @@
 package com.example.onboarding_backend_java.security.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j(topic = "JWTUtil")
+@Component
 public class JWTUtil {
+
+    private Key key;
+
+    public JWTUtil(@Value("${jwt.secret.key}") String secret) {
+        byte[] byteSecretKey = Decoders.BASE64.decode(secret);
+        key = Keys.hmacShaKeyFor(byteSecretKey);
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    public String createToken(String username, String role, Long expiredMs) {
+        Claims claims = Jwts.claims();
+        claims.put("username", username);
+        claims.put("role", role);
+        log.info("Creating token with claims: {}", claims);
+
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+        log.info("Token created successfully");
+        return token;
+    }
+
 }


### PR DESCRIPTION
## 개요
- 사용자가 로그인할 수 있도록 `/sign` API를 구현
- 로그인 성공 시 Access Token을 발급하여 response header에 포함하도록 구현

## 구현 내용
### 1. 필요한 클래스 생성(or 수정 or 추가)
   - `SignRequestDto`: 로그인 요청을 위한 DTO
   - `JWTAuthenticationFilter`: 로그인 검증용 Filter
   - `JWTUtil`: JWT 생성, 검증 메서드 구현, 사용자 정보 토큰에 저장
### 2. 로그인 API (`POST/sign`) 구현
   - 사용자가 `username`, `password`를 입력하면 JWT Access Token을 발급
   - Access Token은 응답 헤더(`access-token`)에 포함하여 반환
   - `/sign`, `/signup`, `/` 등의 엔드포인트는 `permitAll`
   - 그 외 요청은 인증 필요
### 3. 비밀번호 검증
   - `BCryptPasswordEncoder`를 사용하여 입력된 비밀번호와 저장된 비밀번호를 비교
### 4. 예외처리
- `username`이 존재하지 않으면 401 에러 반환
- `password`가 틀리면 401 에러 반환

## 테스트
- [ ] 존재하는 `username`과 올바른 `password` 입력 시 Access Token이 정상 발급되는지 확인
- [ ]  존재하지 않는 `username` 입력 시 401 에러 발생 확인
- [ ]  잘못된 `password` 입력 시 401 에러 발생 확인

관련 이슈
#5 