### PR TITLE
feat: 로그인 기능 확장(JWT Refresh Token 적용 및 쿠키 저장)

### DIFF
--- a/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
+++ b/src/main/java/com/example/onboarding_backend_java/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.onboarding_backend_java.config;
 import com.example.onboarding_backend_java.security.jwt.JWTAuthenticationFilter;
 import com.example.onboarding_backend_java.security.jwt.JWTAuthorizationFilter;
 import com.example.onboarding_backend_java.security.jwt.JWTUtil;
+import com.example.onboarding_backend_java.security.jwt.refresh.RefreshService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,8 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
+    private final RefreshService refreshService;
+
 
 
     @Bean
@@ -37,7 +40,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         JWTAuthenticationFilter jwtFilter =
-                new JWTAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+                new JWTAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshService);
         jwtFilter.setFilterProcessesUrl("/sign");
 
         http
@@ -45,7 +48,7 @@ public class SecurityConfig {
                 .formLogin((auth) -> auth.disable())
                 .httpBasic((auth) -> auth.disable())
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/sign", "/", "/signup").permitAll()
+                        .requestMatchers("/sign", "/", "/signup", "/refresh").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JWTAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthenticationFilter.java
@@ -1,13 +1,14 @@
 package com.example.onboarding_backend_java.security.jwt;
 
 import com.example.onboarding_backend_java.dto.SignRequestDto;
-import com.example.onboarding_backend_java.security.CustomUserDetails;
+import com.example.onboarding_backend_java.security.jwt.refresh.RefreshService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,12 +20,15 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static com.example.onboarding_backend_java.security.jwt.refresh.CookieUtil.createCookie;
+
 @Slf4j
 @RequiredArgsConstructor
 public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
+    private final RefreshService refreshService;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
@@ -53,8 +57,8 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             HttpServletResponse response,
             FilterChain chain,
             Authentication authentication) throws IOException {
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-        String username = customUserDetails.getUsername();
+
+        String username = authentication.getName();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -63,11 +67,18 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String role = auth.getAuthority();
         log.info("successfulAuthentication: username={}, role={}", username, role);
 
-        String token = jwtUtil.createToken(username, role, 60 * 60 * 10 * 1000L);
-        log.info("Generated token: {}", token);
+        String accessToken = jwtUtil.createToken("access", username, role, 600000L);
+        log.info("Generated accessToken: {}", accessToken);
 
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"token\":\"" + token + "\"}");
+        String refreshToken = jwtUtil.createToken("refresh", username, role, 86400000L);
+        log.info("Generated refreshToken: {}", refreshToken);
+
+        refreshService.deleteRefreshToken(refreshToken);
+        refreshService.saveRefreshToken(username, refreshToken, 86400000L);
+
+        response.setHeader("access", accessToken);
+        response.addCookie(createCookie("refresh", refreshToken));
+        response.setStatus(HttpStatus.OK.value());
     }
 
     @Override

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthorizationFilter.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTAuthorizationFilter.java
@@ -3,6 +3,7 @@ package com.example.onboarding_backend_java.security.jwt;
 import com.example.onboarding_backend_java.entity.Role;
 import com.example.onboarding_backend_java.entity.User;
 import com.example.onboarding_backend_java.security.CustomUserDetails;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -27,46 +28,61 @@ public class JWTAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
 
-            String authorization = request.getHeader("Authorization");
+            String accessToken = request.getHeader("access");
 
-            if (authorization == null || !authorization.startsWith("Bearer ")) {
-
-                log.info("token null");
-                filterChain.doFilter(request, response);
-                return;
-            }
-            log.info("authorization now");
-
-            String token = authorization.substring(7);
-
-            if (jwtUtil.isExpired(token)) {
-                log.info("token expired");
+            if (accessToken == null) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            String username = jwtUtil.getUsername(token);
-            String role = jwtUtil.getRole(token);
+            try {
+                jwtUtil.isExpired(accessToken);
+            } catch (ExpiredJwtException e) {
+                log.warn("토큰이 만료되었습니다.");
+
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write("{\"error\": \"토큰 만료\"}");
+                return;
+            }
+
+            String category = jwtUtil.getCategory(accessToken);
+            if (!"access".equals(category)) {
+                log.warn("유효하지 않은 토큰입니다.");
+
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write("{\"error\": \"유효하지 않은 토큰\"}");
+                return;
+            }
+
+            String username = jwtUtil.getUsername(accessToken);
+            String role = jwtUtil.getRole(accessToken);
 
             User user = new User();
             user.setUsername(username);
-            user.setPassword("temppassword");
             user.setRole(Role.valueOf(role));
 
             CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
             Authentication authToken = new UsernamePasswordAuthenticationToken(
                     customUserDetails,
                     null,
                     customUserDetails.getAuthorities()
             );
             SecurityContextHolder.getContext().setAuthentication(authToken);
+            log.info("User authenticated - username: {}, role: {}", username, role);
 
             filterChain.doFilter(request, response);
+
         } catch(JwtException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("인가 중 서버 및 내부 오류 발생: ", e.getMessage(), e);
-            throw e;
+            log.error("인가 중 서버 및 내부 오류 발생: ", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("{\"error\": \"Internal server error\"}");
         }
     }
 }

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTUtil.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/JWTUtil.java
@@ -51,11 +51,12 @@ public class JWTUtil {
                 .before(new Date());
     }
 
-    public String createToken(String username, String role, Long expiredMs) {
+    public String createToken(String category, String username, String role, Long expiredMs) {
         Claims claims = Jwts.claims();
+        claims.put("category", category);
         claims.put("username", username);
         claims.put("role", role);
-        log.info("Creating token with claims: {}", claims);
+        log.info("Creating token for category: {}, username: {}, role: {}", category, username, role);
 
         String token = Jwts.builder()
                 .setClaims(claims)
@@ -65,6 +66,15 @@ public class JWTUtil {
                 .compact();
         log.info("Token created successfully");
         return token;
+    }
+
+    public String getCategory(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("category", String.class);
     }
 
 }

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/dto/TokenRequestDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/dto/TokenRequestDto.java
@@ -1,4 +1,0 @@
-package com.example.onboarding_backend_java.security.jwt.dto;
-
-public class TokenRequestDto {
-}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/dto/TokenResponseDto.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/dto/TokenResponseDto.java
@@ -1,4 +1,0 @@
-package com.example.onboarding_backend_java.security.jwt.dto;
-
-public class TokenResponseDto {
-}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/CookieUtil.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/CookieUtil.java
@@ -1,0 +1,16 @@
+package com.example.onboarding_backend_java.security.jwt.refresh;
+
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtil {
+
+    public static Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(86400);
+        // cookie.setSecure(true);
+        // cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/Refresh.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/Refresh.java
@@ -1,0 +1,36 @@
+package com.example.onboarding_backend_java.security.jwt.refresh;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Refresh {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date expiration;
+
+    public static Refresh create(String username, String refreshToken, Date expiration) {
+        return Refresh.builder()
+                .username(username)
+                .refreshToken(refreshToken)
+                .expiration(expiration)
+                .build();
+    }
+}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/RefreshController.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/RefreshController.java
@@ -1,0 +1,73 @@
+package com.example.onboarding_backend_java.security.jwt.refresh;
+
+import com.example.onboarding_backend_java.security.jwt.JWTUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.onboarding_backend_java.security.jwt.refresh.CookieUtil.createCookie;
+
+@RestController
+@RequiredArgsConstructor
+public class RefreshController {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshService refreshService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response) {
+
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh".equals(cookie.getName())) {
+                    refreshToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        if (refreshToken == null) {
+            return new ResponseEntity<>("refreshToken이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (!refreshService.existsByRefreshToken(refreshToken)) {
+            return new ResponseEntity<>("존재하지 않는 refreshToken입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            jwtUtil.isExpired(refreshToken);
+        } catch (ExpiredJwtException e) {
+            refreshService.deleteRefreshToken(refreshToken);
+            return new ResponseEntity<>("refreshToken이 만료되었습니다.", HttpStatus.UNAUTHORIZED);
+        }
+
+        String category = jwtUtil.getCategory(refreshToken);
+
+        if (!"refresh".equals(category)) {
+            return new ResponseEntity<>("유효하지 않은 refreshToken입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        String username = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
+
+        String newAccessToken = jwtUtil.createToken("access", username, role, 600000L);
+        String newRefreshToken = jwtUtil.createToken("refresh", username, role, 86400000L);
+
+        refreshService.deleteRefreshToken(refreshToken);
+        refreshService.saveRefreshToken(username, newRefreshToken, 86400000L);
+
+        response.setHeader("access", newAccessToken);
+        response.addCookie(createCookie("refresh", newRefreshToken));
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/RefreshRepository.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/RefreshRepository.java
@@ -1,0 +1,12 @@
+package com.example.onboarding_backend_java.security.jwt.refresh;
+
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshRepository extends JpaRepository<Refresh, Long> {
+
+    Boolean existsByRefreshToken(String refreshToken);
+
+    @Transactional
+    void deleteByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/RefreshService.java
+++ b/src/main/java/com/example/onboarding_backend_java/security/jwt/refresh/RefreshService.java
@@ -1,0 +1,33 @@
+package com.example.onboarding_backend_java.security.jwt.refresh;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshService {
+
+    private final RefreshRepository refreshRepository;
+
+    @Transactional
+    public void saveRefreshToken(String username, String refreshToken, Long expiredMs) {
+        Date expirationDate = new Date(System.currentTimeMillis() + expiredMs);
+
+        refreshRepository.deleteByRefreshToken(refreshToken);
+
+        Refresh refresh = Refresh.create(username, refreshToken, expirationDate);
+        refreshRepository.save(refresh);
+    }
+
+    public boolean existsByRefreshToken(String refreshToken) {
+        return refreshRepository.existsByRefreshToken(refreshToken);
+    }
+
+    @Transactional
+    public void deleteRefreshToken(String refreshToken) {
+        refreshRepository.deleteByRefreshToken(refreshToken);
+    }
+}


### PR DESCRIPTION
## 개요
- 기존 로그인 로직에 Refresh Token을 적용
- Access Token 만료 시 자동으로 갱신할 수 있도록 구현
- Access Token은 응답 헤더에 포함
- Refresh Token은 HttpOnly 쿠키에 저장

## 구현 내용
### 1. JWT Access & Refresh Token 생성
- 로그인 성공 시, Access Token & Refresh Token 함께 발급
- `JWTUtil.createToken()`을 사용하여 두 개의 토큰 생성
### 2. 로그인 API (`POST /sign`) 수정
- Request message는 동일 -> Response 변경
  - Request:
```
{
  "username": "JIN HO",
  "password": "12341234"
}
```
  - Response (헤더 + 쿠키 포함):
```
Headers:
- access-token: eKDIkdfjoakIdkfjpekdkcjdkoIOdjOKJDFOlLDKFJKL

Cookies:
- refreshToken=OQJDFOlLDKFJKLdjokjfkdjpekdkcjdko; HttpOnly; Secure
```
### 3. Refresh Token을 DB에 저장
- 로그인할 때마다 기존 Refresh Token 삭제 후 새로 저장(중복 저장 방지)
- `RefreshService.saveRefreshToken()`을 이용해 DB에 Refresh Token 저장
### 4. Refresh Token을 쿠키에 저장 (`HttpOnly` 설정)
- `response.addCookie(CookieUtil.createCookie("refresh", refreshToken))`을 통해 브라우저에서 접근할 수 없도록 설정합니다.
### 5. 예외 처리
- `username`이 존재하지 않으면 401 에러 반환
- `password`가 틀리면 401 에러 반환
## 테스트 사항
 - [ ] 로그인 시 Access Token이 응답 헤더에 포함되는지 확인
- [ ]  로그인 시 Refresh Token이 HttpOnly 쿠키에 저장되는지 확인
- [ ]  Refresh Token이 DB에 정상적으로 저장되는지 확인
- [ ]  중복 로그인 시 기존 Refresh Token이 삭제되고 새로운 Token이 저장되는지 확인

관련 Issue
#8 